### PR TITLE
Add image popup

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,8 +3,6 @@ extra:
   analytics:
     provider: google
     property: G-9MPBK2ZXGH
-extra_css:
-  - assets/css/styles.css
 theme:
   name: material
   favicon: assets/favicon.png
@@ -25,7 +23,20 @@ markdown_extensions:
 
   - pymdownx.tabbed:
         alternate_style: true
-
+plugins:
+  - glightbox:
+        touchNavigation: true
+        loop: false
+        effect: zoom
+        slide_effect: slide
+        width: 100%
+        height: auto
+        zoomable: true
+        draggable: true
+        skip_classes:
+            - custom-skip-class-name
+        auto_caption: false
+        caption_position: bottom
 
 nav:
   - "index.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,8 @@ extra:
   analytics:
     provider: google
     property: G-9MPBK2ZXGH
+extra_css:
+  - assets/css/styles.css
 theme:
   name: material
   favicon: assets/favicon.png

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 mkdocs-material
 mkdocs-pdf-export-plugin
+mkdocs-glightbox


### PR DESCRIPTION
With this merge will add a plugin for images popup support.
All images will have the feature.
For config and turning off for some images change config in root/mkdocs.yml:
- glightbox:
   touchNavigation: true
   loop: false
   effect: zoom
   slide_effect: slide
   width: 100%
   height: auto
   zoomable: true
   draggable: true
   skip_classes:
      - custom-skip-class-name
   auto_caption: false
   caption_position: bottom
   
read more on documentation: https://github.com/blueswen/mkdocs-glightbox